### PR TITLE
Instead of storing n strings for each ngram, only store the corresponding hash

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -11,7 +11,6 @@
 #include <math.h>
 #include <boost/make_unique.hpp>
 #include <vector>
-#include <memory>
 
 #include "utils/CompressedWriter.h"
 
@@ -74,10 +73,10 @@ namespace align {
           for (size_t order = 1; order <= ngram_size; ++order) {
             map_it = test_counts.begin(order);
             while (map_it != test_counts.end(order)) {
-              int cooktarget_count = cooktarget.at(c).get(map_it->first);
+              int cooktarget_count = cooktarget.at(c).get(map_it->first, order);
               if (cooktarget_count > 0) {
                 // update correct counts
-                int test_count = test_counts.get(map_it->first);
+                int test_count = test_counts.get(map_it->first, order);
                 cooked_test_correct.at(order - 1) += std::min(cooktarget_count, test_count);
               }
 

--- a/src/ngram.cpp
+++ b/src/ngram.cpp
@@ -8,7 +8,6 @@
 #include <memory>
 
 #include <boost/make_unique.hpp>
-#include <boost/functional/hash.hpp>
 
 
 namespace ngram {
@@ -17,29 +16,27 @@ namespace ngram {
       data.assign(n, ngram_map());
     }
 
-    int NGramCounter::get(const NGramContainer &key) {
-      size_t idx = get_map_index(key);
-      ngram_map::iterator it;
-      it = data.at(idx).find(key);
+    size_t NGramCounter::get(const NGram &key) const {
+      size_t idx = key.size - 1;
+      ngram_map::const_iterator it = data.at(idx).find(key);
 
-      if (it != data.at(idx).end()) {
+      if (it != data.at(idx).cend()) {
         return it->second;
       } else {
         return 0;
       }
     }
 
-    void NGramCounter::increment(const NGramContainer &ng) {
-      size_t map_idx = get_map_index(ng);
-      ngram_map::iterator it;
-      it = data.at(map_idx).find(ng);
+    void NGramCounter::increment(const NGram &ng) {
+      size_t map_idx = ng.size - 1;
+      ngram_map::iterator it = data.at(map_idx).find(ng);
 
       if (it != data.at(map_idx).end()) {
         // FOUND
-        it->second = it->second + 1;
+        ++it->second;
       } else {
         // NOT FOUND
-        data.at(map_idx).insert(std::make_pair(ng, 1));
+        data.at(map_idx)[ng] = 1;
       }
 
       ++total_freq;
@@ -47,8 +44,7 @@ namespace ngram {
 
     void NGramCounter::process(std::vector<std::string> &tokens) {
       // set-up iterators
-      std::unique_ptr<std::vector<std::string>::iterator[]> token_iterators(
-              boost::make_unique<std::vector<std::string>::iterator[]>(ngram_size));
+      std::unique_ptr<std::vector<std::string>::iterator[]> token_iterators(boost::make_unique<std::vector<std::string>::iterator[]>(ngram_size));
       for (unsigned short i = 0; i < ngram_size; ++i) {
         token_iterators[i] = tokens.begin();
         std::advance(token_iterators[i], i);
@@ -76,15 +72,15 @@ namespace ngram {
                                         unsigned short ngram) {
       switch (ngram) {
         case 4:
-          increment(NGramContainer(token_iterators[ngram - 4]->c_str(), token_iterators[ngram - 3]->c_str(),
-                                   token_iterators[ngram - 2]->c_str(), token_iterators[ngram - 1]->c_str()));
+          increment(NGram(*token_iterators[ngram - 4], *token_iterators[ngram - 3],
+                          *token_iterators[ngram - 2], *token_iterators[ngram - 1]));
         case 3:
-          increment(NGramContainer(token_iterators[ngram - 3]->c_str(), token_iterators[ngram - 2]->c_str(),
-                                   token_iterators[ngram - 1]->c_str()));
+          increment(NGram(*token_iterators[ngram - 3], *token_iterators[ngram - 2],
+                          *token_iterators[ngram - 1]));
         case 2:
-          increment(NGramContainer(token_iterators[ngram - 2]->c_str(), token_iterators[ngram - 1]->c_str()));
+          increment(NGram(*token_iterators[ngram - 2], *token_iterators[ngram - 1]));
         case 1:
-          increment(NGramContainer(token_iterators[ngram - 1]->c_str()));
+          increment(NGram(*token_iterators[ngram - 1]));
           break;
       }
     }
@@ -97,28 +93,6 @@ namespace ngram {
       return num;
     }
 
-    size_t NGramCounter::get_map_index(const NGramContainer &key) {
-      return key.data()->size() - 1;
-    }
-
-    bool operator==(const NGramContainer &a, const NGramContainer &b) {
-      if (a.data()->size() != b.data()->size()) return false;
-
-      for (size_t i = 0; i < a.data()->size(); ++i) {
-        if (a.data()->at(i) != b.data()->at(i)) return false;
-      }
-
-      return true;
-    }
-
-    std::size_t hash_value(const NGramContainer &e) {
-      std::size_t seed = 0;
-
-      for (size_t i = 0; i < e.data()->size(); ++i) {
-        boost::hash_combine(seed, e.data()->at(i));
-      }
-
-      return seed;
-    }
-
+    bool operator==(const NGram &a, const NGram &b) {return a.hash == b.hash;}
+    size_t hash_value(const NGram &ng) {return ng.hash;}
 }

--- a/src/ngram.cpp
+++ b/src/ngram.cpp
@@ -12,26 +12,8 @@
 
 
 namespace ngram {
-    size_t get_ngram_hash(const std::string& a){
-      return util::MurmurHashNative(a.c_str(), a.size());
-    }
-
-    size_t get_ngram_hash(const std::string &a, const std::string &b){
-      size_t hash = util::MurmurHashNative(a.c_str(), a.size());
-      return util::MurmurHashNative(b.c_str(), b.size(), hash);
-    }
-
-    size_t get_ngram_hash(const std::string &a, const std::string &b, const std::string &c){
-      size_t hash = util::MurmurHashNative(a.c_str(), a.size());
-      hash = util::MurmurHashNative(b.c_str(), b.size(), hash);
-      return util::MurmurHashNative(c.c_str(), c.size(), hash);
-    }
-
-    size_t get_ngram_hash(const std::string &a, const std::string &b, const std::string& c, const std::string& d){
-      size_t hash = util::MurmurHashNative(a.c_str(), a.size());
-      hash = util::MurmurHashNative(b.c_str(), b.size(), hash);
-      hash = util::MurmurHashNative(c.c_str(), c.size(), hash);
-      return util::MurmurHashNative(d.c_str(), d.size(), hash);
+    size_t get_token_hash(const std::string &token, size_t seed){
+      return util::MurmurHashNative(token.c_str(), token.size(), seed);
     }
 
     NGramCounter::NGramCounter(unsigned short n) : ngram_size(n) {
@@ -92,18 +74,10 @@ namespace ngram {
 
     void NGramCounter::increment_helper(const std::unique_ptr<std::vector<std::string>::iterator[]> &token_iterators,
                                         unsigned short ngram) {
-      switch (ngram) {
-        case 4:
-          increment(get_ngram_hash(*token_iterators[ngram - 4], *token_iterators[ngram - 3],
-                                  *token_iterators[ngram - 2], *token_iterators[ngram - 1]), 4);
-        case 3:
-          increment(get_ngram_hash(*token_iterators[ngram - 3], *token_iterators[ngram - 2],
-                                  *token_iterators[ngram - 1]), 3);
-        case 2:
-          increment(get_ngram_hash(*token_iterators[ngram - 2], *token_iterators[ngram - 1]), 2);
-        case 1:
-          increment(get_ngram_hash(*token_iterators[ngram - 1]), 1);
-          break;
+      size_t hash = 0;
+      for (unsigned short i = 1; i <= ngram; ++i){
+        hash = get_token_hash(*token_iterators[ngram-i], hash);
+        increment(hash, i);
       }
     }
 

--- a/src/ngram.h
+++ b/src/ngram.h
@@ -11,10 +11,7 @@
 
 namespace ngram {
 
-    size_t get_ngram_hash(const std::string &a);
-    size_t get_ngram_hash(const std::string &a, const std::string &b);
-    size_t get_ngram_hash(const std::string &a, const std::string &b, const std::string &c);
-    size_t get_ngram_hash(const std::string &a, const std::string &b, const std::string &c, const std::string &d);
+    size_t get_token_hash(const std::string &token, size_t seed = 0);
 
     typedef boost::unordered_map<size_t, size_t> ngram_map;
 

--- a/src/ngram.h
+++ b/src/ngram.h
@@ -2,68 +2,21 @@
 #ifndef FAST_BLEUALIGN_NGRAMS_H
 #define FAST_BLEUALIGN_NGRAMS_H
 
-#include "util/murmur_hash.hh"
-
 #include <iostream>
 #include <string>
 #include <vector>
 #include <iterator>
-#include <memory>
-#include <type_traits>
 
 #include <boost/unordered_map.hpp>
 
 namespace ngram {
 
-    struct NGram {
-      size_t hash;
-      size_t size;
+    size_t get_ngram_hash(const std::string &a);
+    size_t get_ngram_hash(const std::string &a, const std::string &b);
+    size_t get_ngram_hash(const std::string &a, const std::string &b, const std::string &c);
+    size_t get_ngram_hash(const std::string &a, const std::string &b, const std::string &c, const std::string &d);
 
-      // unigram
-      NGram(const std::string &a) {
-        // calc hash of a 
-        hash = 0;
-        compute_hash(a);
-        size = 1;
-      }
-
-      // bigram
-      NGram(const std::string &a, const std::string &b) {
-        hash = 0;
-        compute_hash(a);
-        compute_hash(b);
-        size = 2;
-      }
-
-      // trigram
-      NGram(const std::string &a, const std::string &b, const std::string &c) {
-        hash = 0;
-        compute_hash(a);
-        compute_hash(b);
-        compute_hash(c);
-        size = 3;
-      }
-
-      // quadgram
-      NGram(const std::string &a, const std::string &b, const std::string &c, const std::string &d){
-        hash = 0;
-        compute_hash(a);
-        compute_hash(b);
-        compute_hash(c);
-        compute_hash(d);
-        size = 4;
-      }
-
-      void compute_hash(const std::string& a){
-        hash = util::MurmurHashNative(a.c_str(), a.size(), hash);
-      }
-
-    };
-
-    bool operator==(const NGram &a, const NGram &b);
-    size_t hash_value(const NGram &ng);
-
-    typedef boost::unordered_map<NGram, size_t> ngram_map;
+    typedef boost::unordered_map<size_t, size_t> ngram_map;
 
     class NGramCounter {
 
@@ -73,30 +26,30 @@ namespace ngram {
 
         ~NGramCounter() {};
 
-        size_t get(const NGram &key) const;
+        size_t get(size_t key, unsigned short ngram) const;
 
-        ngram_map::iterator begin(size_t ngram) {
+        ngram_map::iterator begin(unsigned short ngram) {
           return data.at(ngram - 1).begin();
         }
 
-        ngram_map::iterator end(size_t ngram) {
+        ngram_map::iterator end(unsigned short ngram) {
           return data.at(ngram - 1).end();
         }
 
-        void increment(const NGram &ng);
+        void increment(size_t key, unsigned short ngram);
 
         void process(std::vector<std::string> &tokens);
 
         inline void
-        increment_helper(std::unique_ptr<std::vector<std::string>::iterator[]> &token_iterators, unsigned short ngram);
+        increment_helper(const std::unique_ptr<std::vector<std::string>::iterator[]> &token_iterators, unsigned short ngram);
 
-        size_t count_tokens();
+        size_t count_tokens() const;
 
-        size_t count_frequencies() {
+        size_t count_frequencies() const {
           return total_freq;
         }
 
-        size_t processed() {
+        size_t processed() const {
           return tokens_processed;
         }
 

--- a/tests/test_ngram.cpp
+++ b/tests/test_ngram.cpp
@@ -222,9 +222,9 @@ namespace {
       ngram::NGramCounter ngc_lorem1(1);
       ngc_lorem1.process(tokens_lorem1);
       ASSERT_EQ(ngc_lorem1.count_tokens(), 63);
-      ASSERT_EQ(ngc_lorem1.get(ngram::get_ngram_hash("etincidunt"), 1), 50);
-      ASSERT_EQ(ngc_lorem1.get(ngram::get_ngram_hash("est"), 1), 41);
-      ASSERT_EQ(ngc_lorem1.get(ngram::get_ngram_hash("Modi"), 1), 2);
+      ASSERT_EQ(ngc_lorem1.get(ngram::get_token_hash("etincidunt"), 1), 50);
+      ASSERT_EQ(ngc_lorem1.get(ngram::get_token_hash("est"), 1), 41);
+      ASSERT_EQ(ngc_lorem1.get(ngram::get_token_hash("Modi"), 1), 2);
 
       std::vector<std::string> tokens_lorem2 = {"Dolorem", "voluptatem", "sed", "voluptatem", "amet", "sed", "sed",
                                                 "porro",
@@ -325,9 +325,10 @@ namespace {
       ngram::NGramCounter ngc_lorem2(2);
       ngc_lorem2.process(tokens_lorem2);
       ASSERT_EQ(ngc_lorem2.count_tokens(), 465);
-      ASSERT_EQ(ngc_lorem2.get(ngram::get_ngram_hash("voluptatem", "velit"), 2), 2);
-      ASSERT_EQ(ngc_lorem2.get(ngram::get_ngram_hash("aliquam"), 1), 20);
-      ASSERT_EQ(ngc_lorem2.get(ngram::get_ngram_hash("amet", "sit"), 2), 5);
+      ASSERT_EQ(ngc_lorem2.get(ngram::get_token_hash("voluptatem",
+                                ngram::get_token_hash("velit")), 2), 2);
+      ASSERT_EQ(ngc_lorem2.get(ngram::get_token_hash("aliquam"), 1), 20);
+      ASSERT_EQ(ngc_lorem2.get(ngram::get_token_hash("amet", ngram::get_token_hash("sit")), 2), 5);
 
       std::vector<std::string> tokens_lorem3 = {"Dolore", "labore", "amet", "dolorem", "porro", "numquam", "ipsum",
                                                 "eius",
@@ -619,9 +620,12 @@ namespace {
       ngram::NGramCounter ngc_lorem3(3);
       ngc_lorem3.process(tokens_lorem3);
       ASSERT_EQ(ngc_lorem3.count_tokens(), 2197);
-      ASSERT_EQ(ngc_lorem3.get(ngram::get_ngram_hash("velit", "magnam"), 2), 6);
-      ASSERT_EQ(ngc_lorem3.get(ngram::get_ngram_hash("neque"), 1), 64);
-      ASSERT_EQ(ngc_lorem3.get(ngram::get_ngram_hash("ut", "quisquam", "voluptatem"), 3), 2);
+      ASSERT_EQ(ngc_lorem3.get(ngram::get_token_hash("velit",
+                                ngram::get_token_hash("magnam")), 2), 6);
+      ASSERT_EQ(ngc_lorem3.get(ngram::get_token_hash("neque"), 1), 64);
+      ASSERT_EQ(ngc_lorem3.get(ngram::get_token_hash("ut",
+                                ngram::get_token_hash("quisquam",
+                                ngram::get_token_hash("voluptatem"))), 3), 2);
 
       std::vector<std::string> tokens_lorem4 = {"Magnam", "amet", "ipsum", "modi", "modi", "numquam", "tempora",
                                                 "quiquia",
@@ -822,10 +826,15 @@ namespace {
       ngram::NGramCounter ngc_lorem4(4);
       ngc_lorem4.process(tokens_lorem4);
       ASSERT_EQ(ngc_lorem4.count_tokens(), 2597);
-      ASSERT_EQ(ngc_lorem4.get(ngram::get_ngram_hash("consectetur.", "Eius", "consectetur", "dolor"), 4), 1);
-      ASSERT_EQ(ngc_lorem4.get(ngram::get_ngram_hash("neque"), 1), 45);
-      ASSERT_EQ(ngc_lorem4.get(ngram::get_ngram_hash("quisquam", "quiquia"), 2), 4);
-      ASSERT_EQ(ngc_lorem4.get(ngram::get_ngram_hash("est", "quaerat"), 2), 3);
+      ASSERT_EQ(ngc_lorem4.get(ngram::get_token_hash("consectetur.",
+                                ngram::get_token_hash("Eius",
+                                ngram::get_token_hash("consectetur",
+                                ngram::get_token_hash("dolor")))), 4), 1);
+      ASSERT_EQ(ngc_lorem4.get(ngram::get_token_hash("neque"), 1), 45);
+      ASSERT_EQ(ngc_lorem4.get(ngram::get_token_hash("quisquam",
+                                ngram::get_token_hash("quiquia")), 2), 4);
+      ASSERT_EQ(ngc_lorem4.get(ngram::get_token_hash("est",
+                                ngram::get_token_hash("quaerat")), 2), 3);
 
       ASSERT_EQ(std::distance(ngc_lorem4.begin(1), ngc_lorem4.end(1)), 76);
       ASSERT_EQ(std::distance(ngc_lorem4.begin(2), ngc_lorem4.end(2)), 651);

--- a/tests/test_ngram.cpp
+++ b/tests/test_ngram.cpp
@@ -222,9 +222,9 @@ namespace {
       ngram::NGramCounter ngc_lorem1(1);
       ngc_lorem1.process(tokens_lorem1);
       ASSERT_EQ(ngc_lorem1.count_tokens(), 63);
-      ASSERT_EQ(ngc_lorem1.get(ngram::NGramContainer("etincidunt")), 50);
-      ASSERT_EQ(ngc_lorem1.get(ngram::NGramContainer("est")), 41);
-      ASSERT_EQ(ngc_lorem1.get(ngram::NGramContainer("Modi")), 2);
+      ASSERT_EQ(ngc_lorem1.get(ngram::NGram("etincidunt")), 50);
+      ASSERT_EQ(ngc_lorem1.get(ngram::NGram("est")), 41);
+      ASSERT_EQ(ngc_lorem1.get(ngram::NGram("Modi")), 2);
 
       std::vector<std::string> tokens_lorem2 = {"Dolorem", "voluptatem", "sed", "voluptatem", "amet", "sed", "sed",
                                                 "porro",
@@ -325,9 +325,9 @@ namespace {
       ngram::NGramCounter ngc_lorem2(2);
       ngc_lorem2.process(tokens_lorem2);
       ASSERT_EQ(ngc_lorem2.count_tokens(), 465);
-      ASSERT_EQ(ngc_lorem2.get(ngram::NGramContainer("voluptatem", "velit")), 2);
-      ASSERT_EQ(ngc_lorem2.get(ngram::NGramContainer("aliquam")), 20);
-      ASSERT_EQ(ngc_lorem2.get(ngram::NGramContainer("amet", "sit")), 5);
+      ASSERT_EQ(ngc_lorem2.get(ngram::NGram("voluptatem", "velit")), 2);
+      ASSERT_EQ(ngc_lorem2.get(ngram::NGram("aliquam")), 20);
+      ASSERT_EQ(ngc_lorem2.get(ngram::NGram("amet", "sit")), 5);
 
       std::vector<std::string> tokens_lorem3 = {"Dolore", "labore", "amet", "dolorem", "porro", "numquam", "ipsum",
                                                 "eius",
@@ -619,9 +619,9 @@ namespace {
       ngram::NGramCounter ngc_lorem3(3);
       ngc_lorem3.process(tokens_lorem3);
       ASSERT_EQ(ngc_lorem3.count_tokens(), 2197);
-      ASSERT_EQ(ngc_lorem3.get(ngram::NGramContainer("velit", "magnam")), 6);
-      ASSERT_EQ(ngc_lorem3.get(ngram::NGramContainer("neque")), 64);
-      ASSERT_EQ(ngc_lorem3.get(ngram::NGramContainer("ut", "quisquam", "voluptatem")), 2);
+      ASSERT_EQ(ngc_lorem3.get(ngram::NGram("velit", "magnam")), 6);
+      ASSERT_EQ(ngc_lorem3.get(ngram::NGram("neque")), 64);
+      ASSERT_EQ(ngc_lorem3.get(ngram::NGram("ut", "quisquam", "voluptatem")), 2);
 
       std::vector<std::string> tokens_lorem4 = {"Magnam", "amet", "ipsum", "modi", "modi", "numquam", "tempora",
                                                 "quiquia",
@@ -822,10 +822,10 @@ namespace {
       ngram::NGramCounter ngc_lorem4(4);
       ngc_lorem4.process(tokens_lorem4);
       ASSERT_EQ(ngc_lorem4.count_tokens(), 2597);
-      ASSERT_EQ(ngc_lorem4.get(ngram::NGramContainer("consectetur.", "Eius", "consectetur", "dolor")), 1);
-      ASSERT_EQ(ngc_lorem4.get(ngram::NGramContainer("neque")), 45);
-      ASSERT_EQ(ngc_lorem4.get(ngram::NGramContainer("quisquam", "quiquia")), 4);
-      ASSERT_EQ(ngc_lorem4.get(ngram::NGramContainer("est", "quaerat")), 3);
+      ASSERT_EQ(ngc_lorem4.get(ngram::NGram("consectetur.", "Eius", "consectetur", "dolor")), 1);
+      ASSERT_EQ(ngc_lorem4.get(ngram::NGram("neque")), 45);
+      ASSERT_EQ(ngc_lorem4.get(ngram::NGram("quisquam", "quiquia")), 4);
+      ASSERT_EQ(ngc_lorem4.get(ngram::NGram("est", "quaerat")), 3);
 
       ASSERT_EQ(std::distance(ngc_lorem4.begin(1), ngc_lorem4.end(1)), 76);
       ASSERT_EQ(std::distance(ngc_lorem4.begin(2), ngc_lorem4.end(2)), 651);

--- a/tests/test_ngram.cpp
+++ b/tests/test_ngram.cpp
@@ -222,9 +222,9 @@ namespace {
       ngram::NGramCounter ngc_lorem1(1);
       ngc_lorem1.process(tokens_lorem1);
       ASSERT_EQ(ngc_lorem1.count_tokens(), 63);
-      ASSERT_EQ(ngc_lorem1.get(ngram::NGram("etincidunt")), 50);
-      ASSERT_EQ(ngc_lorem1.get(ngram::NGram("est")), 41);
-      ASSERT_EQ(ngc_lorem1.get(ngram::NGram("Modi")), 2);
+      ASSERT_EQ(ngc_lorem1.get(ngram::get_ngram_hash("etincidunt"), 1), 50);
+      ASSERT_EQ(ngc_lorem1.get(ngram::get_ngram_hash("est"), 1), 41);
+      ASSERT_EQ(ngc_lorem1.get(ngram::get_ngram_hash("Modi"), 1), 2);
 
       std::vector<std::string> tokens_lorem2 = {"Dolorem", "voluptatem", "sed", "voluptatem", "amet", "sed", "sed",
                                                 "porro",
@@ -325,9 +325,9 @@ namespace {
       ngram::NGramCounter ngc_lorem2(2);
       ngc_lorem2.process(tokens_lorem2);
       ASSERT_EQ(ngc_lorem2.count_tokens(), 465);
-      ASSERT_EQ(ngc_lorem2.get(ngram::NGram("voluptatem", "velit")), 2);
-      ASSERT_EQ(ngc_lorem2.get(ngram::NGram("aliquam")), 20);
-      ASSERT_EQ(ngc_lorem2.get(ngram::NGram("amet", "sit")), 5);
+      ASSERT_EQ(ngc_lorem2.get(ngram::get_ngram_hash("voluptatem", "velit"), 2), 2);
+      ASSERT_EQ(ngc_lorem2.get(ngram::get_ngram_hash("aliquam"), 1), 20);
+      ASSERT_EQ(ngc_lorem2.get(ngram::get_ngram_hash("amet", "sit"), 2), 5);
 
       std::vector<std::string> tokens_lorem3 = {"Dolore", "labore", "amet", "dolorem", "porro", "numquam", "ipsum",
                                                 "eius",
@@ -619,9 +619,9 @@ namespace {
       ngram::NGramCounter ngc_lorem3(3);
       ngc_lorem3.process(tokens_lorem3);
       ASSERT_EQ(ngc_lorem3.count_tokens(), 2197);
-      ASSERT_EQ(ngc_lorem3.get(ngram::NGram("velit", "magnam")), 6);
-      ASSERT_EQ(ngc_lorem3.get(ngram::NGram("neque")), 64);
-      ASSERT_EQ(ngc_lorem3.get(ngram::NGram("ut", "quisquam", "voluptatem")), 2);
+      ASSERT_EQ(ngc_lorem3.get(ngram::get_ngram_hash("velit", "magnam"), 2), 6);
+      ASSERT_EQ(ngc_lorem3.get(ngram::get_ngram_hash("neque"), 1), 64);
+      ASSERT_EQ(ngc_lorem3.get(ngram::get_ngram_hash("ut", "quisquam", "voluptatem"), 3), 2);
 
       std::vector<std::string> tokens_lorem4 = {"Magnam", "amet", "ipsum", "modi", "modi", "numquam", "tempora",
                                                 "quiquia",
@@ -822,10 +822,10 @@ namespace {
       ngram::NGramCounter ngc_lorem4(4);
       ngc_lorem4.process(tokens_lorem4);
       ASSERT_EQ(ngc_lorem4.count_tokens(), 2597);
-      ASSERT_EQ(ngc_lorem4.get(ngram::NGram("consectetur.", "Eius", "consectetur", "dolor")), 1);
-      ASSERT_EQ(ngc_lorem4.get(ngram::NGram("neque")), 45);
-      ASSERT_EQ(ngc_lorem4.get(ngram::NGram("quisquam", "quiquia")), 4);
-      ASSERT_EQ(ngc_lorem4.get(ngram::NGram("est", "quaerat")), 3);
+      ASSERT_EQ(ngc_lorem4.get(ngram::get_ngram_hash("consectetur.", "Eius", "consectetur", "dolor"), 4), 1);
+      ASSERT_EQ(ngc_lorem4.get(ngram::get_ngram_hash("neque"), 1), 45);
+      ASSERT_EQ(ngc_lorem4.get(ngram::get_ngram_hash("quisquam", "quiquia"), 2), 4);
+      ASSERT_EQ(ngc_lorem4.get(ngram::get_ngram_hash("est", "quaerat"), 2), 3);
 
       ASSERT_EQ(std::distance(ngc_lorem4.begin(1), ngc_lorem4.end(1)), 76);
       ASSERT_EQ(std::distance(ngc_lorem4.begin(2), ngc_lorem4.end(2)), 651);


### PR DESCRIPTION
Use MurmurHash from preprocess to hash ngrams, and store only that hash instead of strings 