### PR TITLE
Use sorted vectors for sentence representation in alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ if (BUILD_TEST)
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON
+        CMAKE_ARGS -DCMAKE_CXX_FLAGS=-std=c++11
     )
 
     # Include

--- a/main.cpp
+++ b/main.cpp
@@ -23,6 +23,7 @@ void Process(float bleu_threshold) {
     utils::DecodeAndSplit(doc_pair.text1translated, split_line[4], '\n');
     align::AlignDocument(doc_pair, bleu_threshold);
     matches.clear();
+    std::cout << std::flush;
   }
 }
 

--- a/src/ngram.cpp
+++ b/src/ngram.cpp
@@ -1,91 +1,93 @@
-
 #include "ngram.h"
 #include "util/murmur_hash.hh"
 
-#include <iostream>
 #include <string>
 #include <vector>
 #include <iterator>
 #include <memory>
+#include <numeric>
+#include <iterator>
 
-#include <boost/make_unique.hpp>
+
+namespace {
+  typedef std::vector<std::string>::const_iterator token_iterator;
+
+  size_t increment_helper(std::vector<token_iterator> const &token_iterators,
+                   unsigned short ngram,
+                   std::vector<ngram::ngram_map> &maps) {
+    size_t hash = 0;
+    for (unsigned short i = 1; i <= ngram; ++i){
+      hash = ngram::get_token_hash(*token_iterators[ngram-i], hash);
+      maps[i - 1][hash] += 1;
+    }
+    return ngram; // number of iterations of the for-loop
+  }
+}
 
 
 namespace ngram {
-    size_t get_token_hash(const std::string &token, size_t seed){
-      return util::MurmurHashNative(token.c_str(), token.size(), seed);
+  size_t get_token_hash(const std::string &token, size_t seed){
+    return util::MurmurHashNative(token.c_str(), token.size(), seed);
+  }
+
+  NGramCounter::NGramCounter(unsigned short n) : ngram_size_(n) {
+    data_.resize(n);
+  }
+
+  size_t NGramCounter::get(size_t key, unsigned short ngram) const {
+    // No need to be fast, only used for tests anyway
+    for (ngram_pair const &pair : data_[ngram - 1])
+      if (pair.first == key)
+        return pair.second;
+
+    return 0;
+  }
+
+  void NGramCounter::process(std::vector<std::string> const &tokens) {
+    data_.clear();
+    data_.resize(ngram_size_);
+    
+    total_freq_ = 0;
+    tokens_processed_ = tokens.size();
+
+    if (tokens.empty())
+      return;
+
+    // Set up hash maps
+    std::vector<ngram_map> maps(ngram_size_);
+
+    // set-up iterators
+    std::vector<::token_iterator> token_iterators(ngram_size_);
+
+    for (unsigned short i = 0; i < ngram_size_; ++i) {
+      token_iterators[i] = tokens.begin();
+      std::advance(token_iterators[i], i);
     }
 
-    NGramCounter::NGramCounter(unsigned short n) : ngram_size(n) {
-      data.assign(n, ngram_map());
+    // base
+    for (unsigned short i = 1; i < ngram_size_; ++i) {
+      total_freq_ += ::increment_helper(token_iterators, i, maps);
     }
 
-    size_t NGramCounter::get(size_t key, unsigned short ngram) const {
-      size_t idx = ngram - 1;
-      ngram_map::const_iterator it = data.at(idx).find(key);
+    // continue
+    while (token_iterators[ngram_size_ - 1] != tokens.end()) {
+      total_freq_ += ::increment_helper(token_iterators, ngram_size_, maps);
 
-      if (it != data.at(idx).cend()) {
-        return it->second;
-      } else {
-        return 0;
-      }
+      for (unsigned short i = 0; i < ngram_size_; ++i)
+        ++token_iterators[i];
     }
 
-    void NGramCounter::increment(size_t key, unsigned short ngram) {
-      size_t map_idx = ngram - 1;
-      ngram_map::iterator it = data.at(map_idx).find(key);
-
-      if (it != data.at(map_idx).end()) {
-        // FOUND
-        ++it->second;
-      } else {
-        // NOT FOUND
-        data.at(map_idx)[key] = 1;
-      }
-
-      ++total_freq;
+    // convert maps to sorted vectors
+    for (unsigned short i = 0; i < ngram_size_; ++i) {
+      data_[i].reserve(maps[i].size());
+      std::move(maps[i].begin(), maps[i].end(), std::back_inserter(data_[i]));
+      std::sort(data_[i].begin(), data_[i].end()); // sorts by first
     }
+  }
 
-    void NGramCounter::process(std::vector<std::string> &tokens) {
-      if (tokens.empty()) return;
-      // set-up iterators
-      std::unique_ptr<std::vector<std::string>::iterator[]> token_iterators(boost::make_unique<std::vector<std::string>::iterator[]>(ngram_size));
-      for (unsigned short i = 0; i < ngram_size; ++i) {
-        token_iterators[i] = tokens.begin();
-        std::advance(token_iterators[i], i);
-      }
-      // base
-      for (unsigned short i = 0; i < ngram_size - 1; ++i) {
-        increment_helper(token_iterators, i + 1);
-      }
-
-      // continue
-      while (token_iterators[ngram_size - 1] != tokens.end()) {
-        increment_helper(token_iterators, ngram_size);
-
-        for (unsigned short i = 0; i < ngram_size; ++i) {
-          ++token_iterators[i];
-        }
-      }
-
-      tokens_processed += tokens.size();
-
-    }
-
-    void NGramCounter::increment_helper(const std::unique_ptr<std::vector<std::string>::iterator[]> &token_iterators,
-                                        unsigned short ngram) {
-      size_t hash = 0;
-      for (unsigned short i = 1; i <= ngram; ++i){
-        hash = get_token_hash(*token_iterators[ngram-i], hash);
-        increment(hash, i);
-      }
-    }
-
-    size_t NGramCounter::count_tokens() const {
-      size_t num = 0;
-      for (auto s: data) {
-        num += s.size();
-      }
-      return num;
-    }
+  size_t NGramCounter::count_tokens() const {
+    return std::accumulate(data_.begin(), data_.end(), 0, [](size_t acc, ngram_vector const &map) {
+      return acc + map.size();
+    });
+  }
 }

--- a/src/ngram.cpp
+++ b/src/ngram.cpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include <numeric>
 #include <iterator>
-
+#include <algorithm> 
 
 namespace {
   typedef std::vector<std::string>::const_iterator token_iterator;

--- a/src/ngram.h
+++ b/src/ngram.h
@@ -1,4 +1,3 @@
-
 #ifndef FAST_BLEUALIGN_NGRAMS_H
 #define FAST_BLEUALIGN_NGRAMS_H
 
@@ -6,14 +5,17 @@
 #include <string>
 #include <vector>
 #include <iterator>
-
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 namespace ngram {
 
     size_t get_token_hash(const std::string &token, size_t seed = 0);
 
-    typedef boost::unordered_map<size_t, size_t> ngram_map;
+    typedef std::unordered_map<size_t, size_t> ngram_map;
+
+    typedef std::pair<size_t,size_t> ngram_pair;
+
+    typedef std::vector<ngram_pair> ngram_vector;
 
     class NGramCounter {
 
@@ -25,40 +27,33 @@ namespace ngram {
 
         size_t get(size_t key, unsigned short ngram) const;
 
-        ngram_map::const_iterator cbegin(unsigned short ngram) const{
-          return data.at(ngram - 1).cbegin();
+        ngram_vector::const_iterator cbegin(unsigned short ngram) const{
+          return data_.at(ngram - 1).cbegin();
         }
 
-        ngram_map::const_iterator cend(unsigned short ngram) const {
-          return data.at(ngram - 1).cend();
+        ngram_vector::const_iterator cend(unsigned short ngram) const {
+          return data_.at(ngram - 1).cend();
         }
 
-        void increment(size_t key, unsigned short ngram);
-
-        void process(std::vector<std::string> &tokens);
-
-        inline void
-        increment_helper(const std::unique_ptr<std::vector<std::string>::iterator[]> &token_iterators, unsigned short ngram);
+        void process(std::vector<std::string> const &tokens);
 
         size_t count_tokens() const;
 
         size_t count_frequencies() const {
-          return total_freq;
+          return total_freq_;
         }
 
         size_t processed() const {
-          return tokens_processed;
+          return tokens_processed_;
         }
 
     private:
-
-        const unsigned short ngram_size;
-        size_t total_freq = 0;
-        size_t tokens_processed = 0;
-        std::vector<ngram_map> data;
+        const unsigned short ngram_size_;
+        size_t total_freq_ = 0;
+        size_t tokens_processed_ = 0;
+        std::vector<ngram_vector> data_;
 
     };
-
 }
 
 


### PR DESCRIPTION
The resulting vector * vector multiplication ends up being faster than the double hash-table lookup. On small tests with reasonable sentences it's about 30% faster, for larger (problematic) sets, specifically with longer sentences the speed-up is better. As far as I have seen there is no noticeable difference in memory usage.

(I've been using this branch for processing on CSD3 and have encountered one bad_alloc with it, but I'm running 256 copies of it in parallel. Note to self: pt/153/1)