### PR TITLE
Small speed improvements

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,17 +3,20 @@
 #include "src/align.h"
 #include "src/utils/common.h"
 
+#include <fstream>
 #include <iostream>
+#include <string>
+#include <vector>
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
 
-void Process(float bleu_threshold) {
+void Process(std::istream &in, float bleu_threshold) {
   utils::DocumentPair doc_pair;
   utils::matches_vec matches;
   std::string line;
   std::vector<std::string> split_line;
-  while(getline(std::cin, line)) {
+  while(getline(in, line)) {
     split_line.clear();
     utils::SplitString(split_line, line, '\t');
     doc_pair.url1 = split_line[0];
@@ -28,28 +31,38 @@ void Process(float bleu_threshold) {
 }
 
 int main(int argc, char *argv[]) {
+  float bleu_threshold = 0.0f;
+  std::vector<std::string> filenames;  
 
   po::options_description desc("Allowed options");
   desc.add_options()
           ("help", "produce help message")
-          ("bleu-threshold", po::value<float>()->default_value(0.0f), "BLEU threshold for matched sentences");
+          ("bleu-threshold", po::value(&bleu_threshold), "BLEU threshold for matched sentences")
+          ("input-file", po::value(&filenames));
 
+  po::positional_options_description positional;
+  positional.add("input-file", -1);
 
   po::variables_map vm;
-  po::store(po::parse_command_line(argc, reinterpret_cast<const char *const *>(argv), desc), vm);
+  po::store(po::command_line_parser(argc, argv).options(desc).positional(positional).run(), vm);
   po::notify(vm);
 
   if (vm.count("help")) {
-    std::cerr << "Reads matched documents from stdin, outputs aligned sentences to stdout\n" <<
+    std::cerr << "Reads matched documents from input-files or stdin of none specified, outputs aligned sentences to stdout\n" <<
 	    "Tab-separated fields of the input are url1, url2, text1_base64, text2_base64, text1translated_base64\n" <<
 	    "Tab-separated fields of the output are url1, url2, sent1, sent2, score\n\n" <<
+      "Usage: " << argv[0] << " [--help] [--bleu-threshold <threshold>] [<input-file>...]\n\n" <<
 	    desc << std::endl;
     return 1;
   }
 
-  float bleu_threshold = vm["bleu-threshold"].as<float>();
-
-  Process(bleu_threshold);
+  if (filenames.empty())
+    Process(std::cin, bleu_threshold);
+  else
+    for (std::string const &filename : filenames) {
+      std::ifstream fin(filename);
+      Process(fin, bleu_threshold);
+    }
 
   return 0;
 }

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -111,7 +111,7 @@ namespace align {
             // calculate bleu score in reverse direction
             logbleu = 0.0;
             for (size_t order = 1; order <= ngram_size; ++order) {
-              logbleu += log(correct.at(order-1)) - log(std::max<int>(src_counts.processed() - order + 1, 0));
+              logbleu += log(correct[order-1]) - log(std::max<int>(src_counts.processed() - order + 1, 0));
             }
             logbleu /= ngram_size;
             logbleu += std::min<float>(0, 1 - static_cast<float>(trg_counts.processed()) / static_cast<float>(src_counts.processed()));
@@ -185,24 +185,24 @@ namespace align {
           size_t max_pos_translate;
           size_t max_pos_text2;
           for (size_t i = 0; i < scorelist.size(); ++i) {
-            if (scorelist.at(i).size() == 0) {
+            if (scorelist[i].size() == 0) {
               continue;
             }
 
-            if (scorelist.at(i).rbegin()->first > max_val && scorelist.at(i).rbegin()->first > threshold) {
-              max_val = scorelist.at(i).rbegin()->first;
+            if (scorelist[i].rbegin()->first > max_val && scorelist[i].rbegin()->first > threshold) {
+              max_val = scorelist[i].rbegin()->first;
               max_pos_translate = i;
-              max_pos_text2 = scorelist.at(i).rbegin()->second.first;
+              max_pos_text2 = scorelist[i].rbegin()->second.first;
             }
           }
 
           // update match
           if (max_val != -1) {
             m = utils::match(
-                    merged_pos_translated.at(max_pos_translate).first,
-                    merged_pos_translated.at(max_pos_translate).second,
-                    merged_pos_text2.at(max_pos_text2).first,
-                    merged_pos_text2.at(max_pos_text2).second, max_val);
+                    merged_pos_translated[max_pos_translate].first,
+                    merged_pos_translated[max_pos_translate].second,
+                    merged_pos_text2[max_pos_text2].first,
+                    merged_pos_text2[max_pos_text2].second, max_val);
           }
 
 

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -64,6 +64,9 @@ namespace align {
       std::vector<ngram::NGramCounter> src_corpus_ngrams;
       std::vector<std::string> text_normalized;
 
+      // Note: score vector moved here from critical section to prevent constant re-allocation
+      std::vector<int> correct(ngram_size, 0);
+
       // count ngrams for each sentence of the source corpus
       for (const std::string &src_sentence : text2_doc) {
         scorer::normalize(text_normalized, src_sentence, "western");
@@ -83,9 +86,9 @@ namespace align {
 
         utils::scoremap smap;
 
+        // Loop over every source sentence's ngram counts
         size_t src_corpus_i = 0;
         for (const ngram::NGramCounter &src_counts : src_corpus_ngrams) {
-          std::vector<int> correct(ngram_size, 0);
           float logbleu = 0.0;
 
           // compute sum of precision scores for ngrams of order 1 to <ngram_size>

--- a/src/ngram.h
+++ b/src/ngram.h
@@ -27,12 +27,12 @@ namespace ngram {
 
         size_t get(size_t key, unsigned short ngram) const;
 
-        ngram_vector::const_iterator cbegin(unsigned short ngram) const{
-          return data_.at(ngram - 1).cbegin();
+        ngram_vector::const_iterator cbegin(unsigned short ngram) const {
+          return data_[ngram - 1].cbegin();
         }
 
         ngram_vector::const_iterator cend(unsigned short ngram) const {
-          return data_.at(ngram - 1).cend();
+          return data_[ngram - 1].cend();
         }
 
         void process(std::vector<std::string> const &tokens);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -23,14 +23,14 @@ namespace search {
       cols = c + 1;
 
       // initialise
-      scores = boost::make_unique<double[]>(rows * cols);
+      scores = boost::make_unique<float[]>(rows * cols);
       back_pointers = boost::make_unique<char[]>(rows * cols);
 
       std::fill(scores.get(), scores.get() + rows * cols, 0);
       std::fill(back_pointers.get(), back_pointers.get() + rows * cols, '.');
     }
 
-    double *Dynamic::get_score(size_t r, size_t c) {
+    float *Dynamic::get_score(size_t r, size_t c) {
       if ((r > rows - 1) || (c > cols - 1))
         throw std::runtime_error("invalid cost scores access");
 
@@ -57,7 +57,7 @@ namespace search {
         }
       }
 
-      double score, best_score;
+      float score, best_score;
       char pointer;
 
       for (size_t r = 0; r < smap_list.size(); ++r) {
@@ -71,7 +71,7 @@ namespace search {
             pointer = '<';
           }
 
-          boost::unordered_map<utils::sizet_pair, double>::const_iterator got = alignments.find({r, c});
+          boost::unordered_map<utils::sizet_pair, float>::const_iterator got = alignments.find({r, c});
           if (got != alignments.end()) {
             score = got->second + *get_score(r, c);
 
@@ -121,8 +121,8 @@ namespace search {
           j -= 1;
         } else if (pointer == 'm') {
 
-          double score;
-          boost::unordered_map<utils::sizet_pair, double>::const_iterator got = alignments.find({i, j});
+          float score;
+          boost::unordered_map<utils::sizet_pair, float>::const_iterator got = alignments.find({i, j});
           if (got != alignments.end())
             score = got->second;
           else
@@ -511,14 +511,14 @@ namespace search {
     }
 
     void FindMatches(utils::matches_vec &matches, std::vector<utils::scoremap> &scorelist,
-                     size_t translated_size, size_t english_size, double threshold) {
+                     size_t translated_size, size_t english_size, float threshold) {
       Dynamic finder(translated_size, english_size);
       finder.process(scorelist);
       finder.extract_matches(matches);
       FilterMatches(matches, scorelist, threshold);
     }
 
-    void FilterMatches(utils::matches_vec &matches, std::vector<utils::scoremap> &scorelist, double threshold) {
+    void FilterMatches(utils::matches_vec &matches, std::vector<utils::scoremap> &scorelist, float threshold) {
       for (auto m: matches) {
         if (!m.first.same() || !m.second.same())
           throw "Inconsistent data: Only 1:1 alignments can be filtered!";

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -30,18 +30,18 @@ namespace search {
       std::fill(back_pointers.get(), back_pointers.get() + rows * cols, '.');
     }
 
-    float *Dynamic::get_score(size_t r, size_t c) {
+    float &Dynamic::get_score(size_t r, size_t c) {
       if ((r > rows - 1) || (c > cols - 1))
         throw std::runtime_error("invalid cost scores access");
 
-      return &scores[r * cols + c];
+      return scores[(r % 2) * cols + c];
     }
 
-    char *Dynamic::get_backpointer(size_t r, size_t c) {
+    char &Dynamic::get_backpointer(size_t r, size_t c) {
       if ((r > rows - 1) || (c > cols - 1))
         throw std::runtime_error("invalid cost back_pointers access");
 
-      return &back_pointers[r * cols + c];
+      return back_pointers[r * cols + c];
     }
 
     void Dynamic::process(std::vector<utils::scoremap> &smap_list) {
@@ -62,10 +62,10 @@ namespace search {
 
       for (size_t r = 0; r < smap_list.size(); ++r) {
         for (size_t c = 0; c < cols - 1; ++c) {
-          best_score = *get_score(r, c + 1);
+          best_score = get_score(r, c + 1);
           pointer = '^';
 
-          score = *get_score(r + 1, c);
+          score = get_score(r + 1, c);
           if (score > best_score) {
             best_score = score;
             pointer = '<';
@@ -73,7 +73,7 @@ namespace search {
 
           boost::unordered_map<utils::sizet_pair, float>::const_iterator got = alignments.find({r, c});
           if (got != alignments.end()) {
-            score = got->second + *get_score(r, c);
+            score = got->second + get_score(r, c);
 
             if (score > best_score) {
               best_score = score;
@@ -81,8 +81,8 @@ namespace search {
             }
           }
 
-          *get_score(r + 1, c + 1) = best_score;
-          *get_backpointer(r, c) = pointer;
+          get_score(r + 1, c + 1) = best_score;
+          get_backpointer(r, c) = pointer;
 
         }
       }
@@ -100,7 +100,7 @@ namespace search {
 
       for (size_t r = 0; r < rows; ++r) {
         for (size_t c = 0; c < cols; ++c) {
-          std::cout << *(get_backpointer(r, c)) << "\t";
+          std::cout << get_backpointer(r, c) << "\t";
         }
         std::cout << "\n";
       }
@@ -114,7 +114,7 @@ namespace search {
       char pointer;
 
       while (i >= 0 && j >= 0) {
-        pointer = *get_backpointer(i, j);
+        pointer = get_backpointer(i, j);
         if (pointer == '^') {
           i -= 1;
         } else if (pointer == '<') {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -23,10 +23,10 @@ namespace search {
       cols = c + 1;
 
       // initialise
-      scores = boost::make_unique<float[]>(rows * cols);
+      scores = boost::make_unique<float[]>(2 * cols);
       back_pointers = boost::make_unique<char[]>(rows * cols);
 
-      std::fill(scores.get(), scores.get() + rows * cols, 0);
+      std::fill(scores.get(), scores.get() + 2 * cols, 0);
       std::fill(back_pointers.get(), back_pointers.get() + rows * cols, '.');
     }
 
@@ -60,7 +60,7 @@ namespace search {
       float score, best_score;
       char pointer;
 
-      for (size_t r = 0; r < smap_list.size(); ++r) {
+      for (size_t r = 0; r < rows - 1; ++r) {
         for (size_t c = 0; c < cols - 1; ++c) {
           best_score = get_score(r, c + 1);
           pointer = '^';
@@ -90,14 +90,6 @@ namespace search {
 
     void Dynamic::show() {
       std::cout << rows << "x" << cols << "\n";
-      for (size_t r = 0; r < rows; ++r) {
-        for (size_t c = 0; c < cols; ++c) {
-          std::cout << *(get_score(r, c)) << "\t";
-        }
-        std::cout << "\n";
-      }
-      std::cout << "\n------" << std::endl;
-
       for (size_t r = 0; r < rows; ++r) {
         for (size_t c = 0; c < cols; ++c) {
           std::cout << get_backpointer(r, c) << "\t";

--- a/src/search.h
+++ b/src/search.h
@@ -36,7 +36,7 @@ namespace search {
 
         ~Dynamic() {};
 
-        double *get_score(size_t r, size_t c);
+        float *get_score(size_t r, size_t c);
 
         char *get_backpointer(size_t r, size_t c);
 
@@ -52,8 +52,8 @@ namespace search {
         size_t rows = 0;
         size_t cols = 0;
 
-        boost::unordered_map<utils::sizet_pair, double> alignments;
-        std::unique_ptr<double[]> scores;
+        boost::unordered_map<utils::sizet_pair, float> alignments;
+        std::unique_ptr<float[]> scores;
         std::unique_ptr<char[]> back_pointers;
 
     };
@@ -126,9 +126,9 @@ namespace search {
 
 
     void FindMatches(utils::matches_vec &matches, std::vector<utils::scoremap> &scorelist, size_t translated_size,
-                     size_t english_size, double threshold = 0);
+                     size_t english_size, float threshold = 0);
 
-    void FilterMatches(utils::matches_vec &matches, std::vector<utils::scoremap> &scorelist, double threshold = 0);
+    void FilterMatches(utils::matches_vec &matches, std::vector<utils::scoremap> &scorelist, float threshold = 0);
 
 
 }

--- a/src/search.h
+++ b/src/search.h
@@ -36,9 +36,9 @@ namespace search {
 
         ~Dynamic() {};
 
-        float *get_score(size_t r, size_t c);
+        float &get_score(size_t r, size_t c);
 
-        char *get_backpointer(size_t r, size_t c);
+        char &get_backpointer(size_t r, size_t c);
 
         void process(std::vector<utils::scoremap> &smap_list) override;
 


### PR DESCRIPTION
I've replaced the bound-checking vector's `at()` with using the less safe (but faster) `operator[]` operator. Most of these access operations are dictated by ngram_size and iterating from 0 to ngram_size. This eliminated a lot (I mean a lot!) of unnecessary calls to `size()`.

I've also moved the `correct` vector scope outside the hot loop as it was the source of many dynamic allocations but the size never changes & it is completely overwritten in the beginning of the loop anyway.

Without: (compiled for release)
```
time ./bleualign_cpp --bleu-threshold=0.2 ../pt-153-bad.txt > ../pt-153-bad-out~old.txt

________________________________________________________
Executed in  474.10 secs   fish           external
   usr time  444.32 secs  159.00 micros  444.32 secs
   sys time   24.41 secs  1468.00 micros   24.40 secs
```

With:
```
time ./bleualign_cpp --bleu-threshold=0.2 ../pt-153-bad.txt > ../pt-153-bad-out~new.txt

________________________________________________________
Executed in  240.04 secs   fish           external
   usr time  213.35 secs  166.00 micros  213.35 secs
   sys time   22.28 secs  1137.00 micros   22.28 secs
```