### PR TITLE
optional processed version of text 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ file(GLOB bleualign_cpp_headers ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h ${CMAKE_CURR
 file(GLOB bleualign_cpp_cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/utils/*.cpp)
 
 # make bleualign_cpp_lib library
-add_library(bleualign_cpp_lib SHARED ${bleualign_cpp_headers} ${bleualign_cpp_cpp})
+add_library(bleualign_cpp_lib STATIC ${bleualign_cpp_headers} ${bleualign_cpp_cpp})
 target_link_libraries(bleualign_cpp_lib ${Boost_LIBRARIES} preprocess_util)
 
 # bleualign_cpp

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ tests/test_all
 
 Bleualign-cpp takes two texts in two different languages and aligns them to produce parallel sentences. To this end, it also needs a translation of one of these texts.
 
-Input format is `url1 <tab> url2 <tab> text1 <tab> text2 <tab> text1translated` per line. Every text column is encoded as base64. After decoding text columns, they should contain a single sentence per line. The translation (`text1translated`) should correspond line-by-line with the original text (`text1`).
+Input format is `url1 <tab> url2 <tab> text1 <tab> text2 <tab> text1translated [ <tab> text2processed ]` per line. Every text column is encoded as base64. After decoding text columns, they should contain a single sentence per line. The translation (`text1translated`) should correspond line-by-line with the original text (`text1`).
+
+Optionally a processed version of `text2` can be provided, as a sixth column, that better matches the processing applied to `text1translated` to help with calculating alignment scores. The output of bleualign will only mention `text1` and `text2`.
 
 Bleualign-cpp outputs aligned sentences to standard output. Output format is: `url1 <tab> url2 <tab> source_sentence <tab> target_sentence <tab> score` per line.
 

--- a/main.cpp
+++ b/main.cpp
@@ -26,7 +26,7 @@ void Process(std::istream &in, float bleu_threshold) {
 
     // Expect at least 5 (maybe 6) columns
     if (split_line.size() < 5)
-      throw std::runtime_error((std::stringstream() << "Not enough fields on line " << n).str());
+      throw std::runtime_error(((std::stringstream) (std::stringstream() << "Not enough fields on line " << n)).str());
 
     doc_pair.url1 = split_line[0];
     doc_pair.url2 = split_line[1];
@@ -36,10 +36,10 @@ void Process(std::istream &in, float bleu_threshold) {
     // Processed version of text 1 (i.e. translated to match language text 2)
     utils::DecodeAndSplit(doc_pair.text1translated, split_line[4], '\n', true);
     if (doc_pair.text1.size() != doc_pair.text1translated.size())
-      throw std::runtime_error((std::stringstream() 
+      throw std::runtime_error(((std::stringstream) (std::stringstream() 
         << "On line " << n << " column 3 and 5 don't have an equal number of lines ("
         << doc_pair.text1.size() << " vs " << doc_pair.text1translated.size()
-        << ")").str());
+        << ")")).str());
     
     // Optionally sixth column with processed version of text 2 (i.e. to better
     // match with the processed version of text 1)
@@ -49,10 +49,10 @@ void Process(std::istream &in, float bleu_threshold) {
       utils::DecodeAndSplit(doc_pair.text2translated, split_line[5], '\n', true);
 
       if (doc_pair.text2.size() != doc_pair.text2translated.size())
-        throw std::runtime_error((std::stringstream() 
+        throw std::runtime_error(((std::stringstream) (std::stringstream() 
           << "On line " << n << " column 4 and 6 don't have an equal number of lines ("
           << doc_pair.text2.size() << " vs " << doc_pair.text2translated.size()
-          << ")").str());
+          << ")")).str());
     }
 
     align::AlignDocument(doc_pair, bleu_threshold);

--- a/main.cpp
+++ b/main.cpp
@@ -25,8 +25,11 @@ void Process(std::istream &in, float bleu_threshold) {
     utils::SplitString(split_line, line, '\t');
 
     // Expect at least 5 (maybe 6) columns
-    if (split_line.size() < 5)
-      throw std::runtime_error(((std::stringstream) (std::stringstream() << "Not enough fields on line " << n)).str());
+    if (split_line.size() < 5) {
+      std::stringstream error;
+      error << "Not enough fields on line " << n;
+      throw std::runtime_error(error.str());
+    }
 
     doc_pair.url1 = split_line[0];
     doc_pair.url2 = split_line[1];
@@ -35,11 +38,12 @@ void Process(std::istream &in, float bleu_threshold) {
 
     // Processed version of text 1 (i.e. translated to match language text 2)
     utils::DecodeAndSplit(doc_pair.text1translated, split_line[4], '\n', true);
-    if (doc_pair.text1.size() != doc_pair.text1translated.size())
-      throw std::runtime_error(((std::stringstream) (std::stringstream() 
-        << "On line " << n << " column 3 and 5 don't have an equal number of lines ("
-        << doc_pair.text1.size() << " vs " << doc_pair.text1translated.size()
-        << ")")).str());
+    if (doc_pair.text1.size() != doc_pair.text1translated.size()) {
+      std::stringstream error;
+      error << "On line " << n << " column 3 and 5 don't have an equal number of lines ("
+            << doc_pair.text1.size() << " vs " << doc_pair.text1translated.size() << ")";
+      throw std::runtime_error(error.str());
+    }
     
     // Optionally sixth column with processed version of text 2 (i.e. to better
     // match with the processed version of text 1)
@@ -48,11 +52,12 @@ void Process(std::istream &in, float bleu_threshold) {
     } else {
       utils::DecodeAndSplit(doc_pair.text2translated, split_line[5], '\n', true);
 
-      if (doc_pair.text2.size() != doc_pair.text2translated.size())
-        throw std::runtime_error(((std::stringstream) (std::stringstream() 
-          << "On line " << n << " column 4 and 6 don't have an equal number of lines ("
-          << doc_pair.text2.size() << " vs " << doc_pair.text2translated.size()
-          << ")")).str());
+      if (doc_pair.text2.size() != doc_pair.text2translated.size()) {
+        std::stringstream error; 
+        error << "On line " << n << " column 4 and 6 don't have an equal number of lines ("
+              << doc_pair.text2.size() << " vs " << doc_pair.text2translated.size() << ")";
+        throw std::runtime_error(error.str());
+      }
     }
 
     align::AlignDocument(doc_pair, bleu_threshold);

--- a/main.cpp
+++ b/main.cpp
@@ -24,29 +24,35 @@ void Process(std::istream &in, float bleu_threshold) {
 
     utils::SplitString(split_line, line, '\t');
 
+    // Expect at least 5 (maybe 6) columns
     if (split_line.size() < 5)
       throw std::runtime_error((std::stringstream() << "Not enough fields on line " << n).str());
 
     doc_pair.url1 = split_line[0];
     doc_pair.url2 = split_line[1];
-    utils::DecodeAndSplit(doc_pair.text1, split_line[2], '\n');
-    utils::DecodeAndSplit(doc_pair.text2, split_line[3], '\n');
-    utils::DecodeAndSplit(doc_pair.text1translated, split_line[4], '\n');
+    utils::DecodeAndSplit(doc_pair.text1, split_line[2], '\n', true);
+    utils::DecodeAndSplit(doc_pair.text2, split_line[3], '\n', true);
 
+    // Processed version of text 1 (i.e. translated to match language text 2)
+    utils::DecodeAndSplit(doc_pair.text1translated, split_line[4], '\n', true);
     if (doc_pair.text1.size() != doc_pair.text1translated.size())
       throw std::runtime_error((std::stringstream() 
         << "On line " << n << " column 3 and 5 don't have an equal number of lines ("
-        << doc_pair.text1.size() << " vs " << doc_pair.text1translated.size() << ")").str());
-
-    if (split_line.size() == 5)
+        << doc_pair.text1.size() << " vs " << doc_pair.text1translated.size()
+        << ")").str());
+    
+    // Optionally sixth column with processed version of text 2 (i.e. to better
+    // match with the processed version of text 1)
+    if (split_line.size() < 6) {
       doc_pair.text2translated = doc_pair.text2;
-    else {
-      utils::DecodeAndSplit(doc_pair.text2translated, split_line[5], '\n');
+    } else {
+      utils::DecodeAndSplit(doc_pair.text2translated, split_line[5], '\n', true);
 
       if (doc_pair.text2.size() != doc_pair.text2translated.size())
         throw std::runtime_error((std::stringstream() 
           << "On line " << n << " column 4 and 6 don't have an equal number of lines ("
-          << doc_pair.text2.size() << " vs " << doc_pair.text2translated.size() << ")").str());
+          << doc_pair.text2.size() << " vs " << doc_pair.text2translated.size()
+          << ")").str());
     }
 
     align::AlignDocument(doc_pair, bleu_threshold);

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,4 @@
 
-#include "main.h"
 #include "src/align.h"
 #include "src/utils/common.h"
 

--- a/main.h
+++ b/main.h
@@ -1,9 +1,0 @@
-
-#ifndef BLEUALIGN_CPP_MAIN_H
-#define BLEUALIGN_CPP_MAIN_H
-
-#include <string>
-
-void Process(float bleu_threshold);
-
-#endif //BLEUALIGN_CPP_MAIN_H

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -26,7 +26,6 @@ namespace {
       else if (lbegin->first > rbegin->first)
         ++rbegin;
       else {
-        assert(lbegin->first == rbegin->first);
         first_value = op(first_value, lbegin->second, rbegin->second);
         ++lbegin;
         ++rbegin;

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -42,24 +42,24 @@ namespace align {
 
       utils::matches_vec matches;
 
-      Align(matches, doc_pair.text1translated, doc_pair.text2, threshold);
+      Align(matches, doc_pair.text1translated, doc_pair.text2translated, threshold);
       WriteAlignedTextToStdout(matches, doc_pair.text1, doc_pair.text2, doc_pair.url1, doc_pair.url2);
 
     }
 
     void Align(utils::matches_vec &matches, const std::vector<std::string> &text1translated_doc,
-               const std::vector<std::string> &text2_doc, double threshold) {
+               const std::vector<std::string> &text2translated_doc, double threshold) {
 
       std::vector<utils::scoremap> scorelist;
-      EvalSents(scorelist, text1translated_doc, text2_doc, 2, 3);
-      search::FindMatches(matches, scorelist, text1translated_doc.size(), text2_doc.size(), threshold);
-      GapFiller(matches, text1translated_doc, text2_doc, 3, threshold);
+      EvalSents(scorelist, text1translated_doc, text2translated_doc, 2, 3);
+      search::FindMatches(matches, scorelist, text1translated_doc.size(), text2translated_doc.size(), threshold);
+      GapFiller(matches, text1translated_doc, text2translated_doc, 3, threshold);
 
     }
 
     /* given list of test sentences and list of reference sentences, calculate bleu scores */
     void EvalSents(std::vector<utils::scoremap> &scorelist, const std::vector<std::string> &text1translated_doc,
-                   const std::vector<std::string> &text2_doc, unsigned short ngram_size, size_t maxalternatives) {
+                   const std::vector<std::string> &text2translated_doc, unsigned short ngram_size, size_t maxalternatives) {
 
       std::vector<ngram::NGramCounter> src_corpus_ngrams;
       std::vector<std::string> text_normalized;
@@ -68,7 +68,7 @@ namespace align {
       std::vector<int> correct(ngram_size, 0);
 
       // count ngrams for each sentence of the source corpus
-      for (const std::string &src_sentence : text2_doc) {
+      for (const std::string &src_sentence : text2translated_doc) {
         scorer::normalize(text_normalized, src_sentence, "western");
         ngram::NGramCounter counter(ngram_size);
         counter.process(text_normalized);
@@ -138,7 +138,7 @@ namespace align {
     }
 
     void GapFiller(utils::matches_vec &matched, const std::vector<std::string> &text1translated_doc,
-                   const std::vector<std::string> &text2_doc, size_t gap_limit, double threshold) {
+                   const std::vector<std::string> &text2translated_doc, size_t gap_limit, double threshold) {
 
       // check that matches vector contains only 1:1 matches
       for (auto m: matched) {
@@ -147,9 +147,9 @@ namespace align {
       }
 
       std::unique_ptr<int[]> matches_arr_translated = boost::make_unique<int[]>(text1translated_doc.size());
-      std::unique_ptr<int[]> matches_arr_text2 = boost::make_unique<int[]>(text2_doc.size());
+      std::unique_ptr<int[]> matches_arr_text2 = boost::make_unique<int[]>(text2translated_doc.size());
       std::fill(matches_arr_translated.get(), matches_arr_translated.get() + text1translated_doc.size(), -1);
-      std::fill(matches_arr_text2.get(), matches_arr_text2.get() + text2_doc.size(), -1);
+      std::fill(matches_arr_text2.get(), matches_arr_text2.get() + text2translated_doc.size(), -1);
 
 
       for (auto m: matched) {
@@ -168,13 +168,13 @@ namespace align {
           if (post == 0) { // pre
             PreGapMergedSentences(merged_text_translated, merged_pos_translated, text1translated_doc,
                                   matches_arr_translated, m.first.from, gap_limit);
-            PreGapMergedSentences(merged_text_text2, merged_pos_text2, text2_doc,
+            PreGapMergedSentences(merged_text_text2, merged_pos_text2, text2translated_doc,
                                   matches_arr_text2, m.second.from, gap_limit);
           } else if (post == 1) { // post
             PostGapMergedSentences(merged_text_translated, merged_pos_translated, text1translated_doc,
                                    matches_arr_translated, text1translated_doc.size(), m.first.from, gap_limit);
-            PostGapMergedSentences(merged_text_text2, merged_pos_text2, text2_doc,
-                                   matches_arr_text2, text2_doc.size(), m.second.from, gap_limit);
+            PostGapMergedSentences(merged_text_text2, merged_pos_text2, text2translated_doc,
+                                   matches_arr_text2, text2translated_doc.size(), m.second.from, gap_limit);
           }
 
           if (merged_text_translated.size() == 1 && merged_text_text2.size() == 1)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -50,10 +50,9 @@ namespace search {
       }
 
       for (size_t s = 0; s < smap_list.size(); ++s) {
-        utils::scoremap::reverse_iterator it = smap_list.at(s).rbegin();
-        while (it != smap_list.at(s).rend()) {
+        // iterate in reverse order so the entry with the lowest 
+        for (utils::scoremap::reverse_iterator it = smap_list[s].rbegin(), end = smap_list[s].rend(); it != end; ++it) {
           alignments.insert({{s, it->second.first}, it->first});
-          ++it;
         }
       }
 
@@ -516,8 +515,8 @@ namespace search {
           throw "Inconsistent data: Only 1:1 alignments can be filtered!";
       }
 
-      utils::matches_vec matches_cpy(matches);
-      matches.clear();
+      utils::matches_vec matches_cpy;
+      std::swap(matches, matches_cpy);
 
       utils::scoremap::reverse_iterator it;
       for (auto m: matches_cpy) {

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -8,7 +8,7 @@
 #include <boost/algorithm/string.hpp>
 
 namespace utils {
-    void SplitString(std::vector<std::string> &vec, const std::string& str, char delimiter){
+    void SplitString(std::vector<std::string> &vec, const std::string& str, char delimiter, bool trim){
       vec.clear();
       if (str.empty()) return;
       std::string::const_iterator last_it = str.begin();
@@ -18,14 +18,15 @@ namespace utils {
         last_it = it + 1;
         it = std::find(last_it, str.end(), delimiter);
       }
-      vec.emplace_back(std::string(last_it, it));
+      if (!trim || last_it != it)
+        vec.emplace_back(std::string(last_it, it));
     }
 
-    void DecodeAndSplit(std::vector<std::string> &vec, const std::string &str, char delimiter){
+    void DecodeAndSplit(std::vector<std::string> &vec, const std::string &str, char delimiter, bool trim){
         std::string decoded = std::string(binary_text(str.begin()), binary_text(str.end()));
         boost::trim_right_if(decoded, [](char c) {
             return c == '\0';
         });
-        SplitString(vec, decoded, delimiter);
+        SplitString(vec, decoded, delimiter, trim);
     }
 } // namespace utils

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -52,6 +52,9 @@ namespace utils {
     typedef std::vector<sizet_pair> vec_pair;
     typedef std::unordered_map<std::string, std::vector<std::string>> umap_extracted;
     typedef std::vector<std::pair<std::string, std::string>> matches_list;
+
+    // Scoremap stores a list of alignments scores for 1 vs N sentences. Key is
+    // the score, values are the 
     typedef std::multimap<float, std::pair<size_t, std::vector<int>>> scoremap;
     typedef std::vector<match> matches_vec;
 
@@ -74,8 +77,8 @@ namespace utils {
     >
     binary_text;
 
-    void SplitString(std::vector<std::string> &vec, const std::string &str, char delimiter);
-    void DecodeAndSplit(std::vector<std::string> &vec, const std::string &str, char delimiter);
+    void SplitString(std::vector<std::string> &vec, const std::string &str, char delimiter, bool trim = false);
+    void DecodeAndSplit(std::vector<std::string> &vec, const std::string &str, char delimiter, bool trim = false);
 } // namespace utils
 
 

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -62,6 +62,7 @@ namespace utils {
         std::vector<std::string> text1;
         std::vector<std::string> text2;
         std::vector<std::string> text1translated;
+        std::vector<std::string> text2translated;
     };
 
     typedef boost::archive::iterators::transform_width<


### PR DESCRIPTION
This pull request adds support for a processed version of the `text2` column in the input.

**Rationale**: for Europat we have an MT system that effectively also applies some preprocessing steps to the translated input (e.g. anything numeric is replaced with generic tokens) To help alignment in bleualign it would be helpful to have the same process applied to the English text. However, in the output, we would like to keep the original text as much as possible.

This change adds support for an optional sixth column that is such a processed version of `text2`. It will only be used for calculations (i.e. everywhere where comparisons to `text1translated` are made). If the input only has five columns, it will fallback to just using `text2` for comparisons.

**Additional input validation**: This change also adds limited input checking to make sure that the number of lines in both the input text and the translated/processed columns have the same number of lines. It will not count any empty trailing lines, so if `text1` has no trailing newline but `text1translated` has (because b64filter added that 😬) it will not complain.

Aside from the added input validation causing crashes while this might have gone unnoticed previously, this change is backwards compatible. Given you didn't give bleualign_cpp a sixth column as input with the expectation it would ignore it, but as far as I know in the Paracrawl pipeline this doesn't happen.