### PR TITLE
Delete unused includes and fixed some warnings

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,6 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <sstream>
 #include <vector>
 #include <stdexcept>
 #include <boost/program_options.hpp>

--- a/src/ngram.cpp
+++ b/src/ngram.cpp
@@ -3,10 +3,7 @@
 
 #include <string>
 #include <vector>
-#include <iterator>
-#include <memory>
 #include <numeric>
-#include <iterator>
 #include <algorithm> 
 
 namespace {

--- a/src/ngram.h
+++ b/src/ngram.h
@@ -21,9 +21,9 @@ namespace ngram {
 
     public:
 
-        NGramCounter(unsigned short n);
+        explicit NGramCounter(unsigned short n);
 
-        ~NGramCounter() {};
+        ~NGramCounter() = default;;
 
         size_t get(size_t key, unsigned short ngram) const;
 

--- a/src/scorer.cpp
+++ b/src/scorer.cpp
@@ -1,7 +1,6 @@
 
 #include "scorer.h"
 #include "ngram.h"
-#include "utils/common.h"
 
 #include <iostream>
 #include <boost/regex.hpp>

--- a/src/scorer.h
+++ b/src/scorer.h
@@ -14,7 +14,7 @@ namespace scorer {
     typedef std::pair<std::regex, std::string> rule_pair;
 
     const static boost::regex tokenize_regex(
-            "([\\{-\\~\\[-\\` -\\&\\(-\\+\\:-\\@\\/])|(?:(?<![0-9])([\\.,]))|(?:([\\.,])(?![0-9]))|(?:(?<=[0-9])(-))");
+            R"(([\{-\~\[-\` -\&\(-\+\:-\@\/])|(?:(?<![0-9])([\.,]))|(?:([\.,])(?![0-9]))|(?:(?<=[0-9])(-)))");
 
     const static rule_pair normalize1_rules[] = {
             std::make_pair(std::regex("<skipped>"), ""),  // strip "skipped" tags

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1,14 +1,11 @@
 
 #include "search.h"
-#include "align.h"
 #include "utils/common.h"
 
-#include <string>
 #include <vector>
 #include <memory>
 #include <limits>
 #include <utility>
-#include <memory>
 
 #include <boost/make_unique.hpp>
 #include <boost/functional/hash.hpp>
@@ -51,7 +48,7 @@ namespace search {
 
       for (size_t s = 0; s < smap_list.size(); ++s) {
         // iterate in reverse order so the entry with the lowest 
-        for (utils::scoremap::reverse_iterator it = smap_list[s].rbegin(), end = smap_list[s].rend(); it != end; ++it) {
+        for (auto it = smap_list[s].rbegin(), end = smap_list[s].rend(); it != end; ++it) {
           alignments.insert({{s, it->second.first}, it->first});
         }
       }
@@ -100,8 +97,8 @@ namespace search {
 
     void Dynamic::extract_matches(utils::matches_vec &res) {
       res.clear();
-      int i = rows - 2;
-      int j = cols - 2;
+      int i = int(rows) - 2;
+      int j = int(cols) - 2;
       char pointer;
 
       while (i >= 0 && j >= 0) {
@@ -167,7 +164,7 @@ namespace search {
     void Munkres::process(std::vector<utils::scoremap> &smap_list) {
       double val;
       for (size_t i = 0; i < smap_list.size(); ++i) {
-        utils::scoremap::reverse_iterator it = smap_list.at(i).rbegin();
+        auto it = smap_list.at(i).rbegin();
         while (it != smap_list.at(i).rend()) {
           if (min_cost)
             val = it->first;
@@ -311,8 +308,8 @@ namespace search {
         for (size_t c = 0; c < cols; ++c) {
           if (*get_cost(r, c) == 0 && !row_cover[r] && !col_cover[c]) {
             *get_mask(r, c) = 1;
-            row_cover[r] = 1;
-            col_cover[c] = 1;
+            row_cover[r] = true;
+            col_cover[c] = true;
           }
         }
       }
@@ -359,8 +356,8 @@ namespace search {
           return true;
         }
 
-        row_cover[zero.first] = 1;
-        col_cover[found_col] = 0;
+        row_cover[zero.first] = true;
+        col_cover[found_col] = false;
       }
 
     }
@@ -380,7 +377,7 @@ namespace search {
     }
 
     size_t Munkres::find_prime_in_row(size_t r) {
-      for (int c = cols - 1; c >= 0; --c) {
+      for (int c = int(cols) - 1; c >= 0; --c) {
         if (*get_mask(r, c) == 2) {
           return c;
         }
@@ -390,7 +387,7 @@ namespace search {
     }
 
     size_t Munkres::find_star_in_row(size_t r) {
-      for (int c = cols - 1; c >= 0; --c) {
+      for (int c = int(cols) - 1; c >= 0; --c) {
         if (*get_mask(r, c) == 1) {
           return c;
         }
@@ -400,7 +397,7 @@ namespace search {
     }
 
     size_t Munkres::find_star_in_col(size_t c) {
-      for (int r = rows - 1; r >= 0; --r) {
+      for (int r = int(rows) - 1; r >= 0; --r) {
         if (*get_mask(r, c) == 1) {
           return r;
         }
@@ -512,7 +509,7 @@ namespace search {
     void FilterMatches(utils::matches_vec &matches, std::vector<utils::scoremap> &scorelist, float threshold) {
       for (auto m: matches) {
         if (!m.first.same() || !m.second.same())
-          throw "Inconsistent data: Only 1:1 alignments can be filtered!";
+          throw std::runtime_error("Inconsistent data: Only 1:1 alignments can be filtered!");
       }
 
       utils::matches_vec matches_cpy;

--- a/src/search.h
+++ b/src/search.h
@@ -34,7 +34,7 @@ namespace search {
 
         Dynamic(size_t rows, size_t cols);
 
-        ~Dynamic() {};
+        ~Dynamic() = default;;
 
         float &get_score(size_t r, size_t c);
 
@@ -65,7 +65,7 @@ namespace search {
 
         Munkres(size_t rows, size_t cols, bool min_cost = true);
 
-        ~Munkres() {};
+        ~Munkres() = default;;
 
         void process(std::vector<utils::scoremap> &smap_list);
 

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <vector>
 
-#include <boost/functional.hpp>
 #include <boost/algorithm/string.hpp>
 
 namespace utils {

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -24,7 +24,7 @@ namespace utils {
 
             inner(size_t a, size_t b) : from(a), to(b) {};
 
-            bool same() { return from == to; };
+            bool same() const { return from == to; };
 
         };
 
@@ -36,7 +36,7 @@ namespace utils {
 
         match(size_t a, size_t b, size_t c, size_t d, double s) : first(a, b), second(c, d) {score=s;};
 
-        void print() {
+        void print() const {
           printf("(%zu, %zu) -> (%zu, %zu): %f\n", first.from, first.to, second.from, second.to, score);
         }
 
@@ -50,8 +50,6 @@ namespace utils {
 
     typedef std::pair<size_t, size_t> sizet_pair;
     typedef std::vector<sizet_pair> vec_pair;
-    typedef std::unordered_map<std::string, std::vector<std::string>> umap_extracted;
-    typedef std::vector<std::pair<std::string, std::string>> matches_list;
 
     // Scoremap stores a list of alignments scores for 1 vs N sentences. Key is
     // the score, values are the 

--- a/tests/test_align.cpp
+++ b/tests/test_align.cpp
@@ -1,9 +1,7 @@
 
 #include "gtest/gtest.h"
 #include "../src/align.h"
-#include "../src/utils/common.h"
 
-#include <iostream>
 #include <string>
 #include <vector>
 #include <boost/make_unique.hpp>

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1,13 +1,8 @@
 
 #include "gtest/gtest.h"
 #include "../src/search.h"
-#include "../src/align.h"
 
-#include <iostream>
-#include <string>
 #include <vector>
-#include <set>
-
 
 using namespace search;
 


### PR DESCRIPTION
Before I upload changes on Murmurhash hashes for deferred standoff annotation, I noticed some unused includes and warnings while compiling it. I hope I didn't break anything, as tests pass, but I only tested it on my Ubuntu machine.