### PR TITLE
Add header to input and output files and paragraph identification support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -34,6 +34,17 @@ void Process(std::istream &in, float bleu_threshold, bool print_sent_hash, bool 
     }
   }
 
+  // Print output header
+  std::cout << "src_url\ttrg_url\tsrc_text\ttrg_text\tbleualign_score";
+
+  if (paragraph_identification)
+    std::cout << "\tsrc_paragraph_id\ttrg_paragraph_id";
+
+  if (print_sent_hash)
+    std::cout << "\tsrc_deferred_hash\ttrg_deferred_hash";
+
+  std::cout << "\n";
+
   while(getline(in, line)) {
     ++n;
 

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -341,17 +341,6 @@ namespace align {
                                   const std::string& url2,
                                   const bool print_sent_hash,
                                   const bool paragraph_identification) {
-      // Print header
-      std::cout << "src_url\ttrg_url\tsrc_text\ttrg_text\tbleualign_score";
-
-      if (paragraph_identification)
-        std::cout << "\tsrc_paragraph_id\ttrg_paragraph_id";
-
-      if (print_sent_hash)
-        std::cout << "\tsrc_deferred_hash\ttrg_deferred_hash";
-
-      std::cout << "\n";
-
       for (auto m: matches) {
         std::cout << url1 << "\t" << url2 << "\t";
 

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -341,6 +341,16 @@ namespace align {
                                   const std::string& url2,
                                   const bool print_sent_hash,
                                   const bool paragraph_identification) {
+      // Print header
+      std::cout << "src_url\ttrg_url\tsrc_text\ttrg_text\tbleualign_score";
+
+      if (paragraph_identification)
+        std::cout << "\tsrc_paragraph_id\ttrg_paragraph_id";
+
+      if (print_sent_hash)
+        std::cout << "\tsrc_deferred_hash\ttrg_deferred_hash";
+
+      std::cout << "\n";
 
       for (auto m: matches) {
         std::cout << url1 << "\t" << url2 << "\t";


### PR DESCRIPTION
The input file will have to contain a header which describes each column, and an output header will be printed. Changes:

- The expected headers are: *src_url*, *trg_url*, *src_text*, *trg_text* and *src_translated*. The field *trg_translated* is optional.
- The output header fields will be *src_url*, *trg_url*, *src_text*, *trg_text* and *bleualign_score*. If the flag `--paragraph-identification` is set, the fields *src_paragraph_id* and *trg_paragraph_id* will be added as well. If the flag `--print-sent-hash` is set, the fields *src_deferred_hash* and *trg_deferred_hash* will be added as well.

If the text data provided in the input file contains paragraph identification information in TSV format once base64-decoded, the flag `--paragraph-identification` should be set. Changes:

- If the data provided in the fields *src_text* and *trg_text* contain paragraph identification information, it will be used to properly format the output fields.
- If >=2 sentences are joined due to gap filler feature, the paragraph id. inf. will be joined as well.

These changes have been tested with basic configuration of the tool and, apparently, does not add any unexpected behaviour beyond the mentioned input and output headers or the properly format of the paragraph id. inf.

PS: this branch contains, unintentionally, the changes of the branch *paragraph_identification*.