### PR TITLE
Paragraph identification

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@
 
 namespace po = boost::program_options;
 
-void Process(std::istream &in, float bleu_threshold, bool print_sent_hash) {
+void Process(std::istream &in, float bleu_threshold, bool print_sent_hash, bool paragraph_identification) {
   utils::DocumentPair doc_pair;
   std::string line;
   std::vector<std::string> split_line;
@@ -59,7 +59,7 @@ void Process(std::istream &in, float bleu_threshold, bool print_sent_hash) {
       }
     }
 
-    align::AlignDocument(doc_pair, bleu_threshold, print_sent_hash);
+    align::AlignDocument(doc_pair, bleu_threshold, print_sent_hash, paragraph_identification);
     std::cout << std::flush;
   }
 }
@@ -67,6 +67,7 @@ void Process(std::istream &in, float bleu_threshold, bool print_sent_hash) {
 int main(int argc, char *argv[]) {
   float bleu_threshold = 0.0f;
   bool print_sent_hash = false;
+  bool paragraph_identification = false;
   std::vector<std::string> filenames;  
 
   po::options_description desc("Allowed options");
@@ -74,6 +75,7 @@ int main(int argc, char *argv[]) {
           ("help", "produce help message")
           ("bleu-threshold", po::value(&bleu_threshold), "BLEU threshold for matched sentences")
           ("print-sent-hash", po::bool_switch(&print_sent_hash)->default_value(false), "print Murmurhash hashes of the output sentences")
+          ("paragraph-identification", po::bool_switch(&paragraph_identification)->default_value(false), "sentences from input contain tab separated paragraph identification data")
           ("input-file", po::value(&filenames));
 
   po::positional_options_description positional;
@@ -87,17 +89,17 @@ int main(int argc, char *argv[]) {
     std::cerr << "Reads matched documents from input-files or stdin of none specified, outputs aligned sentences to stdout\n" <<
 	    "Tab-separated fields of the input are url1, url2, text1_base64, text2_base64, text1translated_base64 [ ,text2translated_base64 ]\n" <<
 	    "Tab-separated fields of the output are url1, url2, sent1, sent2, score [ , murmurhash_text1, murmurhash_text2 ]\n\n" <<
-      "Usage: " << argv[0] << " [--help] [--bleu-threshold <threshold>] [--print-sent-hash] [<input-file>...]\n\n" <<
+      "Usage: " << argv[0] << " [--help] [--bleu-threshold <threshold>] [--print-sent-hash] [--paragraph-identification] [<input-file>...]\n\n" <<
 	    desc << std::endl;
     return 1;
   }
 
   if (filenames.empty())
-    Process(std::cin, bleu_threshold, print_sent_hash);
+    Process(std::cin, bleu_threshold, print_sent_hash, paragraph_identification);
   else
     for (std::string const &filename : filenames) {
       std::ifstream fin(filename);
-      Process(fin, bleu_threshold, print_sent_hash);
+      Process(fin, bleu_threshold, print_sent_hash, paragraph_identification);
     }
 
   return 0;

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -347,6 +347,7 @@ namespace align {
 
         std::string paragraph_text1 = "";
         std::string paragraph_text2 = "";
+        std::vector<std::string> text1_doc_wo_paragraph, text2_doc_wo_paragraph;
 
         if (paragraph_identification)
         {
@@ -356,24 +357,28 @@ namespace align {
             para_inf = GetParagraphInfo(text1_doc[i]);
             paragraph_text1 += para_inf[1] + "+";
 
+            text1_doc_wo_paragraph.push_back(para_inf[0]);
             std::cout << para_inf[0] << ' ';
           }
 
           para_inf = GetParagraphInfo(text1_doc[m.first.to]);
           paragraph_text1 += para_inf[1];
 
+          text1_doc_wo_paragraph.push_back(para_inf[0]);
           std::cout << para_inf[0] << "\t";
 
           for (size_t i = m.second.from; i < m.second.to; ++i) {
             para_inf = GetParagraphInfo(text2_doc[i]);
             paragraph_text2 += para_inf[1] + "+";
 
+            text2_doc_wo_paragraph.push_back(para_inf[0]);
             std::cout << para_inf[0] << ' ';
           }
 
           para_inf = GetParagraphInfo(text2_doc[m.second.to]);
           paragraph_text2 += para_inf[1];
 
+          text2_doc_wo_paragraph.push_back(para_inf[0]);
           std::cout << para_inf[0] << "\t";
         }
         else
@@ -398,17 +403,27 @@ namespace align {
           std::cout << "\t" << paragraph_text1 << "\t" << paragraph_text2;
         }
 
-        if (print_sent_hash){
-            std::cout << "\t";
-            for (size_t i = m.first.from; i < m.first.to; ++i) {
-                std::cout << std::hex << util::MurmurHashNative(text1_doc[i].c_str(), text1_doc[i].size(), 0) << '+';
-            }
-            std::cout << std::hex << util::MurmurHashNative(text1_doc[m.first.to].c_str(), text1_doc[m.first.to].size(), 0) << "\t";
+        if (print_sent_hash) {
+          std::cout << "\t";
 
-            for (size_t i = m.second.from; i < m.second.to; ++i) {
-                std::cout << std::hex << util::MurmurHashNative(text2_doc[i].c_str(), text2_doc[i].size(), 0) << '+';
-            }
-            std::cout << std::hex << util::MurmurHashNative(text2_doc[m.second.to].c_str(), text2_doc[m.second.to].size(), 0);
+          size_t first1 = paragraph_identification ? 0 : m.first.from;
+          size_t last1 = paragraph_identification ? m.first.to - m.first.from : m.first.to;
+          size_t first2 = paragraph_identification ? 0 : m.second.from;
+          size_t last2 = paragraph_identification ? m.second.to - m.second.from : m.second.to;
+
+          for (size_t i = first1; i < last1; ++i) {
+            std::cout << std::hex << util::MurmurHashNative(paragraph_identification ? text1_doc_wo_paragraph[i].c_str() : text1_doc[i].c_str(),
+                                                            paragraph_identification ? text1_doc_wo_paragraph[i].size() : text1_doc[i].size(), 0) << '+';
+          }
+          std::cout << std::hex << util::MurmurHashNative(paragraph_identification ? text1_doc_wo_paragraph[last1].c_str() : text1_doc[last1].c_str(),
+                                                          paragraph_identification ? text1_doc_wo_paragraph[last1].size() : text1_doc[last1].size(), 0) << "\t";
+
+          for (size_t i = first2; i < last2; ++i) {
+            std::cout << std::hex << util::MurmurHashNative(paragraph_identification ? text2_doc_wo_paragraph[i].c_str() : text2_doc[i].c_str(),
+                                                            paragraph_identification ? text2_doc_wo_paragraph[i].size() : text2_doc[i].size(), 0) << '+';
+          }
+          std::cout << std::hex << util::MurmurHashNative(paragraph_identification ? text2_doc_wo_paragraph[last2].c_str() : text2_doc[last2].c_str(),
+                                                          paragraph_identification ? text2_doc_wo_paragraph[last2].size() : text2_doc[last2].size(), 0);
         }
 
         std::cout << "\n";

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -323,19 +323,24 @@ namespace align {
 
       if (paragraph_data.size() != 2)
       {
-        throw std::runtime_error("Unexpected number of columns! 2 were expected, but got " + std::to_string(paragraph_data.size()));
+        std::cerr << "Warning: unexpected number of columns; 2 were expected, but got ";
+        std::cerr << std::to_string(paragraph_data.size()) << "; returning p-1s-1 as paragraph id" << std::endl;
+
+        paragraph_data.clear();
+        paragraph_data.push_back(paragraph_data[0]);
+        paragraph_data.push_back("p-1s-1");
       }
 
       return paragraph_data;
     }
 
     void WriteAlignedTextToStdout(const utils::matches_vec &matches,
-                                const std::vector<std::string> &text1_doc,
-                                const std::vector<std::string> &text2_doc,
-                                const std::string& url1,
-                                const std::string& url2,
-                                const bool print_sent_hash,
-                                const bool paragraph_identification) {
+                                  const std::vector<std::string> &text1_doc,
+                                  const std::vector<std::string> &text2_doc,
+                                  const std::string& url1,
+                                  const std::string& url2,
+                                  const bool print_sent_hash,
+                                  const bool paragraph_identification) {
 
       for (auto m: matches) {
         std::cout << url1 << "\t" << url2 << "\t";

--- a/src/align.h
+++ b/src/align.h
@@ -12,10 +12,11 @@
 
 namespace align {
 
-    void AlignDocument(const utils::DocumentPair& doc_pair, double threshold, bool print_sent_hash);
+    void AlignDocument(const utils::DocumentPair& doc_pair, double threshold, bool print_sent_hash,
+                       bool paragraph_identification);
 
     void Align(utils::matches_vec &matches, const std::vector<std::string> &text1translated_doc,
-               const std::vector<std::string> &text2_doc, double threshold);
+               const std::vector<std::string> &text2_doc, double threshold, const bool paragraph_identification);
 
     void EvalSents(std::vector<utils::scoremap> &scorelist, const std::vector<std::string> &text1translated_doc,
                    const std::vector<std::string> &text2_doc, unsigned short ngram_size, size_t maxalternatives);
@@ -37,7 +38,11 @@ namespace align {
 
     void FillMatches(std::unique_ptr<int[]> &arr1, std::unique_ptr<int[]> &arr2, utils::match m);
 
-    void WriteAlignedTextToStdout(const utils::matches_vec &matches, const std::vector<std::string> &text1_doc, const std::vector<std::string> &text2_doc, const std::string& url1, const std::string& url2, const bool print_sent_hash);
+    void WriteAlignedTextToStdout(const utils::matches_vec &matches, const std::vector<std::string> &text1_doc,
+                                  const std::vector<std::string> &text2_doc, const std::string& url1, const std::string& url2,
+                                  const bool print_sent_hash, const bool paragraph_identification);
+
+    std::vector<std::string> GetParagraphInfo(const std::string &sentence);
 
 
 } // namespace align


### PR DESCRIPTION
If the text data provided in the input file contains paragraph identification information in TSV format once base64-decoded, the flag `--paragraph-identification` should be set. Changes:

- If the data provided in the source and target text (base64-encoded) contain paragraph identification information, it will be used to properly format the output fields.
- If >=2 sentences are joined due to gap filler feature, the paragraph id. inf. will be joined as well.

These changes have been tested with basic configuration of the tool and, apparently, does not add any unexpected behaviour beyond the mentioned format of the paragraph id. inf.