### PR TITLE
Add header to input and output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ tests/test_all
 
 Bleualign-cpp takes two texts in two different languages and aligns them to produce parallel sentences. To this end, it also needs a translation of one of these texts.
 
-Input format is `url1 <tab> url2 <tab> text1 <tab> text2 <tab> text1translated [ <tab> text2processed ]` per line. Every text column is encoded as base64. After decoding text columns, they should contain a single sentence per line. The translation (`text1translated`) should correspond line-by-line with the original text (`text1`).
+Input format is `url1 <tab> url2 <tab> text1 <tab> text2 <tab> text1translated [ <tab> text2processed ]` per line. Every text column is encoded as base64. After decoding text columns, they should contain a single sentence per line. The translation (`text1translated`) should correspond line-by-line with the original text (`text1`). The first line will be a header where, following the explained format, the expected fields are: `src_url <tab> trg_url <tab> src_text <tab> trg_text <tab> src_translated [ <tab> trg_translated ]`. The first line of the output will contain a header as well which, deppending on the provided arguments, the fields will be: `src_url <tab> trg_url <tab> src_text <tab> trg_text <tab> bleualign_score [ <tab> src_paragraph_id <tab> trg_paragraph_id ] [ <tab> src_deferred_hash <tab> trg_deferred_hash ]`.
 
 Optionally a processed version of `text2` can be provided, as a sixth column, that better matches the processing applied to `text1translated` to help with calculating alignment scores. The output of bleualign will only mention `text1` and `text2`.
 
@@ -35,4 +35,7 @@ Bleualign-cpp outputs aligned sentences to standard output. Output format is: `u
 Bleualign receives input by stdin and writes output to stdout.
 
 ##### Optional Parameters
+* **--help** - Print help dialog
 * **--bleu_threshold** - Sentence-level BLEU score threshold (Default: 0.0)
+* **--print-sent-hash** - Print hash for each sentence
+* **--paragraph-identification** - Take into account that the provided text will contain paragraph identificators. If set, there will be expected that each sentence from the base64 document contains `text <tab> paragraph_identificator`

--- a/main.cpp
+++ b/main.cpp
@@ -7,14 +7,76 @@
 #include <string>
 #include <vector>
 #include <stdexcept>
+#include <algorithm>
+#include <numeric>
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
+
+std::vector<int> ProcessHeader(std::istream &in, bool print_sent_hash, bool paragraph_identification) {
+  std::string line;
+  std::vector<std::string> split_line;
+  std::vector<std::string> header_values = {"src_url", "trg_url", "src_text", "trg_text", "src_translated", "trg_translated"};
+  std::vector<int> header_idxs(header_values.size());
+  size_t mandatory_fields = std::min((size_t)5, header_values.size()); // First, mandatory fields
+  size_t optional_fields = header_values.size() - mandatory_fields ? header_values.size() >= mandatory_fields : 0;
+
+  std::iota(std::begin(header_idxs), std::end(header_idxs), 0); // [0, header_values.size())
+
+  if (header_values.size() != header_idxs.size()) {
+    std::stringstream error;
+    error << "Code error: different size for header and idxs values";
+    throw std::runtime_error(error.str());
+  }
+  if (header_values.size() != mandatory_fields + optional_fields) {
+    std::stringstream error;
+    error << "Code error: incorrect values for mandatory and optional values in header fields";
+    throw std::runtime_error(error.str());
+  }
+
+  // Read header
+  getline(in, line);
+  utils::SplitString(split_line, line, '\t');
+
+  // Get indexes of the header
+  for (size_t i = 0; i < mandatory_fields + optional_fields; ++i) {
+    auto find_result = std::find(split_line.begin(), split_line.end(), header_values[i]);
+
+    if (find_result == std::end(split_line)) {
+      if (i < mandatory_fields) {
+        // Throw error because we could not find the mandatory field
+        std::stringstream error;
+        error << "Mandatory field '" << header_values[i] << "' not found in header";
+        throw std::runtime_error(error.str());
+      } else {
+        // Optional field not found
+        continue;
+      }
+    }
+
+    // Assign the idx of the field
+    header_idxs[i] = find_result - split_line.begin();
+  }
+
+  // Print output header
+  std::cout << "src_url\ttrg_url\tsrc_text\ttrg_text\tbleualign_score";
+
+  if (paragraph_identification)
+    std::cout << "\tsrc_paragraph_id\ttrg_paragraph_id";
+
+  if (print_sent_hash)
+    std::cout << "\tsrc_deferred_hash\ttrg_deferred_hash";
+
+  std::cout << "\n";
+
+  return header_idxs;
+}
 
 void Process(std::istream &in, float bleu_threshold, bool print_sent_hash, bool paragraph_identification) {
   utils::DocumentPair doc_pair;
   std::string line;
   std::vector<std::string> split_line;
+  std::vector<int> header_idxs = ProcessHeader(in, print_sent_hash, paragraph_identification);
 
   size_t n = 0;
 
@@ -30,13 +92,13 @@ void Process(std::istream &in, float bleu_threshold, bool print_sent_hash, bool 
       throw std::runtime_error(error.str());
     }
 
-    doc_pair.url1 = split_line[0];
-    doc_pair.url2 = split_line[1];
-    utils::DecodeAndSplit(doc_pair.text1, split_line[2], '\n', true);
-    utils::DecodeAndSplit(doc_pair.text2, split_line[3], '\n', true);
+    doc_pair.url1 = split_line[header_idxs[0]];
+    doc_pair.url2 = split_line[header_idxs[1]];
+    utils::DecodeAndSplit(doc_pair.text1, split_line[header_idxs[2]], '\n', true);
+    utils::DecodeAndSplit(doc_pair.text2, split_line[header_idxs[3]], '\n', true);
 
     // Processed version of text 1 (i.e. translated to match language text 2)
-    utils::DecodeAndSplit(doc_pair.text1translated, split_line[4], '\n', true);
+    utils::DecodeAndSplit(doc_pair.text1translated, split_line[header_idxs[4]], '\n', true);
     if (doc_pair.text1.size() != doc_pair.text1translated.size()) {
       std::stringstream error;
       error << "On line " << n << " column 3 and 5 don't have an equal number of lines ("
@@ -49,7 +111,7 @@ void Process(std::istream &in, float bleu_threshold, bool print_sent_hash, bool 
     if (split_line.size() < 6) {
       doc_pair.text2translated = doc_pair.text2;
     } else {
-      utils::DecodeAndSplit(doc_pair.text2translated, split_line[5], '\n', true);
+      utils::DecodeAndSplit(doc_pair.text2translated, split_line[header_idxs[5]], '\n', true);
 
       if (doc_pair.text2.size() != doc_pair.text2translated.size()) {
         std::stringstream error; 

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -341,7 +341,6 @@ namespace align {
                                   const std::string& url2,
                                   const bool print_sent_hash,
                                   const bool paragraph_identification) {
-
       for (auto m: matches) {
         std::cout << url1 << "\t" << url2 << "\t";
 


### PR DESCRIPTION
The input file will have to contain a header which describes each column, and an output header will be printed. Changes:

- The expected headers are: *src_url*, *trg_url*, *src_text*, *trg_text* and *src_translated*. The field *trg_translated* is optional.
- The output header fields will be *src_url*, *trg_url*, *src_text*, *trg_text* and *bleualign_score*. If the flag `--paragraph-identification` is set, the fields *src_paragraph_id* and *trg_paragraph_id* will be added as well. If the flag `--print-sent-hash` is set, the fields *src_deferred_hash* and *trg_deferred_hash* will be added as well.

If the text data provided in the input file contains paragraph identification information in TSV format once base64-decoded, the flag `--paragraph-identification` should be set. Changes:

- If the data provided in the fields *src_text* and *trg_text* contain paragraph identification information, it will be used to properly format the output fields.
- If >=2 sentences are joined due to gap filler feature, the paragraph id. inf. will be joined as well.

These changes have been tested with basic configuration of the tool and, apparently, does not add any unexpected behaviour beyond the mentioned input and output headers or the properly format of the paragraph id. inf.

NOTE: Integrate these changes right after creating a MaCoCu data release tag/branch in Bitextor.